### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Brightcove PlayerUI Plugin provides two installation packages for iOS, a sta
 CocoaPods
 --------------
 
-You can use [Cocoapods][cocoapods] to add the PlayerUI Plugin for Brightcove Player SDK to your project.  You can find the latest `Brightcove-Player-SDK-Player-UI` podspec [here][podspecs].
+You can use [CocoaPods][cocoapods] to add the PlayerUI Plugin for Brightcove Player SDK to your project.  You can find the latest `Brightcove-Player-SDK-Player-UI` podspec [here][podspecs].
 
 Static Framework example:
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
